### PR TITLE
Fixing create_step_attachment method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 Pipfile.lock
+.idea/

--- a/zephyr/scale/server/endpoints/endpoints.py
+++ b/zephyr/scale/server/endpoints/endpoints.py
@@ -45,7 +45,7 @@ class TestCaseEndpoints(EndpointTemplate):
 
     def create_step_attachment(self, test_case_key, step_index, file_path):
         """Create a new attachment on the specified Step of a Test Case"""
-        return self.session.post(Paths.CASE_STP_ATTACH.format(test_case_key, step_index),
+        return self.session.post_file(Paths.CASE_STP_ATTACH.format(test_case_key, step_index),
                                  file_path)
 
     def search_cases(self, query, **params):


### PR DESCRIPTION
Curretnly for server instance the create_step_attachment is giving HTTP 500, because we are not posting a file. 
This little adjustment to fix the method and post_file